### PR TITLE
Bump Apache Sling parent POM from 62 to 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Update the Apache Sling parent POM version to pick up the latest upstream fixes, dependency updates, and plugin upgrades included in releases 63 through 66.

- Bumped `sling` parent POM version from `62` to `66` in `pom.xml`

Co-authored-by: Maia <maia@noreply>